### PR TITLE
Include Gatsby ^4.0.0 as a peerDependency, too

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "repository": "https://github.com/onnovisser/gatsby-plugin-glslify"
 }


### PR DESCRIPTION
No conflicts found regarding adding v4 as a peerDependency (https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/)